### PR TITLE
More appropriate exception for root folder removal attempt

### DIFF
--- a/fs/googledrivefs/googledrivefs.py
+++ b/fs/googledrivefs/googledrivefs.py
@@ -11,7 +11,7 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseUpload
 from fs.base import FS
 from fs.enums import ResourceType
-from fs.errors import DirectoryExists, DirectoryExpected, DirectoryNotEmpty, FileExists, FileExpected, InvalidCharsInPath, NoURL, ResourceNotFound, OperationFailed
+from fs.errors import DirectoryExists, DirectoryExpected, DirectoryNotEmpty, FileExists, FileExpected, InvalidCharsInPath, NoURL, ResourceNotFound, OperationFailed, RemoveRootError
 from fs.info import Info
 from fs.iotools import RawWrapper
 from fs.mode import Mode
@@ -306,7 +306,7 @@ class GoogleDriveFS(FS):
 
 	def remove(self, path):
 		if path == '/':
-			raise DirectoryNotEmpty(path=path)
+			raise RemoveRootError()
 		_CheckPath(path)
 		with self._lock:
 			info(f"remove: {path}")
@@ -319,7 +319,7 @@ class GoogleDriveFS(FS):
 
 	def removedir(self, path):
 		if path == '/':
-			raise DirectoryNotEmpty(path=path)
+			raise RemoveRootError()
 		_CheckPath(path)
 		with self._lock:
 			info(f"removedir: {path}")


### PR DESCRIPTION
fs.errors do have RemoveRootError, why not use it instead of DirectoryNotEmpty?