### PR TITLE
GCP Service Account Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,58 @@ You can also use the same method of authentication when using `GoogleDriveFS` di
   fs = GoogleDriveFS(credentials=credentials)
 ```
 
+## Using `fs.googledrivefs` with an organisation's Google Account
+
+While access to the Google Drive API is straightforward to enable for a personal Google Account,
+a user of an organisation's Google Account will typically only be able to enable an API in the
+context of a
+[GCP Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+The user can then configure a 
+[Service Account](https://cloud.google.com/iam/docs/understanding-service-accounts)
+to access all or a sub-set of the user's files using `fs.googledrivefs` with the following steps:
+
+- create a GCP Project
+- enable the Google Drive API for that Project
+- create a Service Account for that Project
+- share any Drive directory (or file) with that Service Account (using the accounts email)
+
+## Notes on forming `fs` urls for GCP Service Accounts
+
+Say that your is drive is structured as follows:
+
+```
+/alldata
+  /data1
+  /data2
+   :
+```
+
+Also say that you have given your application's service account access to everything in `data1`.
+If your application opens url `/alldata/data1` using `fs.opener.open_fs()`, then `fs.googledrivefs`
+must first get the info for `alldata` to which it has no access and so the operation fails. 
+
+To address this we can tell `fs.googledrivefs` to treat `data1` as the root directory by supplying
+the file id of `data1` as the request parameter `root_id`. The fs url you would now use is
+`googledrive:///?root_id=12345678901234567890`: 
+
+```python
+  from fs.opener import open_fs
+
+  fs2 = open_fs("googledrive:///?root_id=12345678901234567890")
+```
+
+You can also use the `rootId` when using `GoogleDriveFS` directly:
+
+```python
+  import google.auth
+  from fs.googledrivefs import GoogleDriveFS
+
+  credentials, _ = google.auth.default()
+  fs = GoogleDriveFS(credentials=credentials, rootId="12345678901234567890")
+```
+
+Note that any file or directory's id is readily accessible from it's web url.
+
 # Development
 
 To run the tests, set the following environment variables:

--- a/README.md
+++ b/README.md
@@ -129,4 +129,13 @@ Then run the tests by executing
   pytest
 ```
 
-in the root directory. The tests may take an hour or two to complete. They create and destroy many, many files and directories mostly under the /test-googledrivefs directory in the user's Google Drive and a few in the root directory
+in the root directory
+(note that if `GOOGLEDRIVEFS_TEST_CREDENTIALS_PATH` isn't set 
+then the test suite will try to use the default Google credentials).
+The tests may take an hour or two to complete.
+They create and destroy many, many files and directories
+mostly under the /test-googledrivefs directory in the user's Google Drive
+and a few in the root directory
+
+Note that, if your tests are run using a service account,
+you can set the root id using `GOOGLEDRIVEFS_TEST_ROOT_ID`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ Implementation of [pyfilesystem2](https://docs.pyfilesystem.org/) file system fo
   # fs2 is now a standard pyfilesystem2 file system
 ```
 
+## Default Google Authentication
+
+If your application is accessing the Google Drive API as a 
+[GCP Service Account](https://cloud.google.com/iam/docs/service-accounts), `fs.googledrivefs` will
+default to authenticating using the Service Account credentials specified by the 
+[`GOOGLE_APPLICATION_CREDENTIALS` environment variable](https://cloud.google.com/docs/authentication/getting-started). 
+This can greatly simplify the URLs used by the opener:
+
+```python
+  from fs.opener import open_fs
+
+  fs2 = open_fs("googledrive:///required/path")
+```
+
+You can also use the same method of authentication when using `GoogleDriveFS` directly:
+
+```python
+  import google.auth
+  from fs.googledrivefs import GoogleDriveFS
+
+  credentials, _ = google.auth.default()
+  fs = GoogleDriveFS(credentials=credentials)
+```
+
 # Development
 
 To run the tests, set the following environment variables:

--- a/fs/googledrivefs/googledrivefs.py
+++ b/fs/googledrivefs/googledrivefs.py
@@ -11,7 +11,7 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseUpload
 from fs.base import FS
 from fs.enums import ResourceType
-from fs.errors import DestinationExists, DirectoryExists, DirectoryExpected, DirectoryNotEmpty, FileExists, FileExpected, InvalidCharsInPath, NoURL, ResourceNotFound, OperationFailed, RemoveRootError
+from fs.errors import DestinationExists, DirectoryExists, DirectoryExpected, DirectoryNotEmpty, FileExists, FileExpected, InvalidCharsInPath, NoURL, ResourceNotFound, OperationFailed, PathError, RemoveRootError
 from fs.info import Info
 from fs.iotools import RawWrapper
 from fs.mode import Mode
@@ -26,6 +26,7 @@ _sharingUrl = "https://drive.google.com/open?id="
 _INVALID_PATH_CHARS = ":\0"
 _log = getLogger("fs.googledrivefs")
 _rootMetadata = {"id": "root", "mimeType": _folderMimeType}
+_ALL_FIELDS = 'id,mimeType,kind,name,createdTime,modifiedTime,size,permissions,appProperties,contentHints,md5Checksum'
 
 def _Escape(name):
 	name = name.replace("\\", "\\\\")
@@ -139,12 +140,13 @@ class SubGoogleDriveFS(SubFS):
 class GoogleDriveFS(FS):
 	subfs_class = SubGoogleDriveFS
 
-	def __init__(self, credentials):
+	def __init__(self, credentials, rootId=None):
 		super().__init__()
 
 		self.drive = build("drive", "v3", credentials=credentials, cache_discovery=False)
 		self.retryCount = 3
 		self.enforceSingleParent = False
+		self.rootId = rootId
 
 		_meta = self._meta = {
 			"case_insensitive": True, # it will even let you have 2 identical filenames in the same directory! But the search is case-insensitive
@@ -165,7 +167,7 @@ class GoogleDriveFS(FS):
 		return (self._infoFromMetadata(x) for x in rawResults)
 
 	def _fileQuery(self, query):
-		allFields = "nextPageToken,files(id,mimeType,kind,name,createdTime,modifiedTime,size,permissions,appProperties,contentHints,md5Checksum)"
+		allFields = f'nextPageToken,files({_ALL_FIELDS})'
 		response = self.drive.files().list(q=query, fields=allFields).execute(num_retries=self.retryCount)
 		result = response["files"]
 		while "nextPageToken" in response:
@@ -193,7 +195,16 @@ class GoogleDriveFS(FS):
 		ipath = iteratepath(path)
 
 		pathSoFar = ""
-		parentId = None
+		parentId = self.rootId
+
+		if self.rootId is not None:
+			# if we have been given a `rootId` then get the info for this directory and set it as
+			# the root directory's metadata.
+			rootMetadata = self.drive.files().get(fileId=self.rootId, fields=_ALL_FIELDS).execute()
+			if rootMetadata is None:
+				return
+			pathIdMap[""] = rootMetadata
+
 		for childName in ipath:
 			pathSoFar = join(pathSoFar, childName)
 			metadata = self._childByName(parentId, childName)

--- a/fs/googledrivefs/googledrivefs.py
+++ b/fs/googledrivefs/googledrivefs.py
@@ -11,7 +11,7 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseUpload
 from fs.base import FS
 from fs.enums import ResourceType
-from fs.errors import DestinationExists, DirectoryExists, DirectoryExpected, DirectoryNotEmpty, FileExists, FileExpected, InvalidCharsInPath, NoURL, ResourceNotFound, OperationFailed, PathError, RemoveRootError
+from fs.errors import DestinationExists, DirectoryExists, DirectoryExpected, DirectoryNotEmpty, FileExists, FileExpected, InvalidCharsInPath, NoURL, ResourceNotFound, OperationFailed, RemoveRootError
 from fs.info import Info
 from fs.iotools import RawWrapper
 from fs.mode import Mode
@@ -26,7 +26,7 @@ _sharingUrl = "https://drive.google.com/open?id="
 _INVALID_PATH_CHARS = ":\0"
 _log = getLogger("fs.googledrivefs")
 _rootMetadata = {"id": "root", "mimeType": _folderMimeType}
-_ALL_FIELDS = 'id,mimeType,kind,name,createdTime,modifiedTime,size,permissions,appProperties,contentHints,md5Checksum'
+_ALL_FIELDS = "id,mimeType,kind,name,createdTime,modifiedTime,size,permissions,appProperties,contentHints,md5Checksum"
 
 def _Escape(name):
 	name = name.replace("\\", "\\\\")
@@ -167,7 +167,7 @@ class GoogleDriveFS(FS):
 		return (self._infoFromMetadata(x) for x in rawResults)
 
 	def _fileQuery(self, query):
-		allFields = f'nextPageToken,files({_ALL_FIELDS})'
+		allFields = f"nextPageToken,files({_ALL_FIELDS})"
 		response = self.drive.files().list(q=query, fields=allFields).execute(num_retries=self.retryCount)
 		result = response["files"]
 		while "nextPageToken" in response:
@@ -202,7 +202,7 @@ class GoogleDriveFS(FS):
 			# the root directory's metadata.
 			rootMetadata = self.drive.files().get(fileId=self.rootId, fields=_ALL_FIELDS).execute()
 			if rootMetadata is None:
-				return
+				return pathIdMap
 			pathIdMap[""] = rootMetadata
 
 		for childName in ipath:

--- a/fs/googledrivefs/opener.py
+++ b/fs/googledrivefs/opener.py
@@ -1,6 +1,7 @@
 __all__ = ["GoogleDriveFSOpener"]
 
 from fs.opener import Opener
+import google.auth
 from google.oauth2.credentials import Credentials # pylint: disable=wrong-import-order
 
 from .googledrivefs import GoogleDriveFS
@@ -11,11 +12,17 @@ class GoogleDriveFSOpener(Opener): # pylint: disable=too-few-public-methods
 	def open_fs(self, fs_url, parse_result, writeable, create, cwd): # pylint: disable=too-many-arguments
 		directory = parse_result.resource
 
-		credentials = Credentials(parse_result.params.get("access_token"),
-			refresh_token=parse_result.params.get("refresh_token", None),
-			token_uri="https://www.googleapis.com/oauth2/v4/token",
-			client_id=parse_result.params.get("client_id", None),
-			client_secret=parse_result.params.get("client_secret", None))
+		if "access_token" in parse_result.params:
+			# if `access_token` parameters are provided then use them..
+			credentials = Credentials(parse_result.params.get("access_token"),
+				refresh_token=parse_result.params.get("refresh_token", None),
+				token_uri="https://www.googleapis.com/oauth2/v4/token",
+				client_id=parse_result.params.get("client_id", None),
+				client_secret=parse_result.params.get("client_secret", None))
+		else:
+			# ..otherwise use default credentials
+			credentials, _ = google.auth.default()
+
 		fs = GoogleDriveFS(credentials)
 
 		if directory:

--- a/fs/googledrivefs/opener.py
+++ b/fs/googledrivefs/opener.py
@@ -1,7 +1,7 @@
 __all__ = ["GoogleDriveFSOpener"]
 
 from fs.opener import Opener
-import google.auth
+import google.auth # pylint: disable=wrong-import-order
 from google.oauth2.credentials import Credentials # pylint: disable=wrong-import-order
 
 from .googledrivefs import GoogleDriveFS

--- a/fs/googledrivefs/opener.py
+++ b/fs/googledrivefs/opener.py
@@ -23,7 +23,7 @@ class GoogleDriveFSOpener(Opener): # pylint: disable=too-few-public-methods
 			# ..otherwise use default credentials
 			credentials, _ = google.auth.default()
 
-		fs = GoogleDriveFS(credentials)
+		fs = GoogleDriveFS(credentials, parse_result.params.get("root_id", None))
 
 		if directory:
 			return fs.opendir(directory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "fs.googledrivefs"
 packages = [
     { include = "fs"}
 ]
-version = "1.7.0"
+version = "1.8.0"
 description = "Pyfilesystem2 implementation for Google Drive"
 authors = ["Rehan Khwaja <rehan@khwaja.name>"]
 license = "MIT"


### PR DESCRIPTION
While access to the Google Drive API is straightforward to enable for a personal Google Account, a user of an organisation's Google Account will typically only be able to enable an API in the context of a
[GCP Project](https://cloud.google.com/resource-manager/docs/reating-managing-projects). The user can then configure a [Service Account](https://cloud.google.com/iam/docs/understanding-service-accounts) to access all or a sub-set of the user's files.

This PR supports this method of access as follows:

- Service account credentials are usually provided by a JSON file. https://github.com/msb/fs.googledrivefs/commit/ccaa802b2592d9174cb257fc5b0ca6e7205f984f allows `fs.googledrivefs` to default to using the default Google credentials which can be configured as said JSON file.
- https://github.com/msb/fs.googledrivefs/commit/9c498072e9eb0177c002adeb92c0b6c8245a3433 supports a `root_id` request parameter in an "fs" url that the allows a sub-directory to be defined as a "root" directory. This allows `fs.googledrivefs` to directly address the sub-directory permissioned to the service account. 
