### PR TITLE
Shared Drive support

### DIFF
--- a/fs/googledrivefs/googledrivefs.py
+++ b/fs/googledrivefs/googledrivefs.py
@@ -276,7 +276,7 @@ class GoogleDriveFS(FS):
 			'sharing': {
 				'id': metadata['id'],
 				'permissions': permissions,
-				'is_shared': len(permissions) > 1 if permissions is not None else None
+				'is_shared': len(permissions) > 1 if permissions is not None else False
 			}
 		}
 		googleMetadata = {}

--- a/fs/googledrivefs/opener.py
+++ b/fs/googledrivefs/opener.py
@@ -23,7 +23,11 @@ class GoogleDriveFSOpener(Opener): # pylint: disable=too-few-public-methods
 			# ..otherwise use default credentials
 			credentials, _ = google.auth.default()
 
-		fs = GoogleDriveFS(credentials, parse_result.params.get('root_id', None))
+		fs = GoogleDriveFS(
+			credentials,
+			rootId=parse_result.params.get('root_id'),
+			driveId=parse_result.params.get('drive_id'),
+		)
 
 		if directory:
 			return fs.opendir(directory)

--- a/tests/test_googledrivefs.py
+++ b/tests/test_googledrivefs.py
@@ -3,6 +3,7 @@ from hashlib import md5
 from json import load, loads
 from os import environ
 from unittest import TestCase, skipUnless
+from urllib.parse import urlencode
 from uuid import uuid4
 
 import google.auth
@@ -200,14 +201,17 @@ def test_opener():
 def test_opener_with_root_id():
 	# (default credentials are used for authentication)
 
-	root_id = environ['GOOGLEDRIVEFS_TEST_ROOT_ID']
+	params = {'root_id': environ['GOOGLEDRIVEFS_TEST_ROOT_ID']}
+	if 'GOOGLEDRIVEFS_TEST_DRIVE_ID' in environ:
+		params['drive_id'] = environ['GOOGLEDRIVEFS_TEST_DRIVE_ID']
+	query = urlencode(params)
 
 	# Without the initial "/" character, it should still be assumed to relative to the root
-	fs = open_fs(f'googledrive://test-googledrivefs?root_id={root_id}')
+	fs = open_fs(f'googledrive://test-googledrivefs?{query}')
 	assert isinstance(fs, SubGoogleDriveFS), str(fs)
 	assert fs._sub_dir == '/test-googledrivefs' # pylint: disable=protected-access
 
 	# It should still accept the initial "/" character
-	fs = open_fs(f'googledrive:///test-googledrivefs?root_id={root_id}')
+	fs = open_fs(f'googledrive:///test-googledrivefs?{query}')
 	assert isinstance(fs, SubGoogleDriveFS), str(fs)
 	assert fs._sub_dir == '/test-googledrivefs' # pylint: disable=protected-access

--- a/tests/test_googledrivefs.py
+++ b/tests/test_googledrivefs.py
@@ -36,7 +36,11 @@ def FullFS():
 	else:
 		credentials, _ = google.auth.default()
 
-	return GoogleDriveFS(credentials, environ.get('GOOGLEDRIVEFS_TEST_ROOT_ID', None))
+	return GoogleDriveFS(
+		credentials,
+		rootId=environ.get('GOOGLEDRIVEFS_TEST_ROOT_ID'),
+		driveId=environ.get('GOOGLEDRIVEFS_TEST_DRIVE_ID'),
+	)
 
 class TestGoogleDriveFS(FSTestCases, TestCase):
 	def make_fs(self):


### PR DESCRIPTION
Shared Drive support needs additional parameters to various `files.*` API calls:
* read operations: `files.get`, `files.list`
* write operations: `files.create`, `files.update`, `files.copy`, `files.delete`

Add opener support:
* `drive_id` query parameter
* works also with `root_id`

Tests:
* `GOOGLEDRIVEFS_TEST_DRIVE_ID` enables Shared Drive mode
* fix `test_opener_with_root_id` to work also with `drive_id`
* all tests pass (using service account)
  * with just `GOOGLEDRIVEFS_TEST_DRIVE_ID`
  * with both `GOOGLEDRIVEFS_TEST_DRIVE_ID` and `GOOGLEDRIVEFS_TEST_ROOT_ID`

Fixes:
* bug found by `test_geturl()` related to `is_shared`:
  * Shared Drive doesn't define `permissions` property for files
  * `hasurl()` ended up returning `None` 

Related specifications:
* https://developers.google.com/drive/api/v3/enable-shareddrives
* https://support.google.com/a/answer/7337554?hl=en Shared Drive access levels
* https://developers.google.com/drive/api/v3/reference/files (some file properties are different when using Shared Drive)

Fixes #56 
